### PR TITLE
Include updates for processing restored +4 K diagnostic data

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,16 @@ $ mamba env create --file envs/environment.yaml
 
 ## Processing the data
 
-The multi-year X-SHiELD simulations were run in two stages, and so the raw data
-exists in two places.  Before running the `snakemake` workflow it is therefore
-important to merge these datasets together through symbolic links.  This can be
-done by calling the included script:
-
-```
-$ conda run --name 2023-09-18-X-SHiELD-snakemake misc/symlink_dataset.py
-```
-
-To process the data, activate the environment from a `screen` session (this will
-take a while), and call the included top-level `submit.sh` bash script.  This
-script handles partitioning the work into a sequence of batch jobs, grouping
-tasks into single jobs where appropriate to prevent overwhelming the SLURM
-scheduler with many small jobs.
+To process the data, activate the environment from a `screen` session, and call
+the included top-level `submit.sh` bash script.  This script handles some
+initial data preparation / organization, as well as partitioning the work into a
+sequence of batch jobs, grouping tasks into single jobs where appropriate to
+prevent overwhelming the SLURM scheduler with many small jobs.
 
 ```
 $ screen
-$ conda run --name 2023-09-18-X-SHiELD-snakemake submit.sh
+$ conda activate 2023-09-18-X-SHiELD-snakemake
+$ bash submit.sh
 ```
 
 ## High-level overview of the workflow
@@ -57,7 +49,7 @@ learning workflow.  At a high level it does the following:
   This arrangement and naming of the restart files is exactly what is required
   for performing an fv3net nudged run.
 
-In total this workflow processes over 140 TB of restart files and 7.3 TB of
+In total this workflow processes over 140 TB of restart files and 7.6 TB of
 diagnostics (we have ignored the 3D diagnostics for now, though they too could
 be processed by this workflow).  By way of coarsening to C48 resolution, this
 data is reduced by a factor of 64 to a more manageable ~2 TB.

--- a/misc/copy_plus_4K_diagnostics.py
+++ b/misc/copy_plus_4K_diagnostics.py
@@ -1,0 +1,51 @@
+# #!/usr/bin/env python
+# There was missing data in the plus-4K case.  Kai copied over data that
+# was already combined for the missing segments.  This does not fit in
+# neatly with our snakemake workflow, which expects uncombined raw data,
+# so we'll need to manually symlink the pre-combined data into the work
+# directory for those segments.
+import glob
+import logging
+import os
+import shutil
+
+from pathlib import Path
+
+
+TRANSFERRED = "transferred"
+ROOT = Path("/scratch/cimes/GLOBALFV3/stellar_run")
+SIMULATION = "20191020.00Z.C3072.L79x2_pire_PLUS_4K"
+SOURCE_ROOT = ROOT / TRANSFERRED / SIMULATION / "history"
+TARGET_ROOT = Path("/scratch/cimes/skclark/2023-09-18-PIRE-X-SHiELD-post-processing/work/plus-4K/diagnostics")
+SEGMENTS = sorted(os.listdir(SOURCE_ROOT))
+RERUN_SEGMENTS = ["2019102000"]  # Needed to be re-run (so uncombined)
+FIRST_UNRESTORED_SEGMENT = "2020022700"
+TAPES = [
+    "pire_atmos_dyn_3h_coarse_inst",
+    "pire_atmos_dyn_plev_coarse_3h",
+    "pire_atmos_phys_3h_coarse",
+    "pire_atmos_static_coarse"
+]
+
+
+def copy(segment):
+    source = SOURCE_ROOT / segment
+    destination = TARGET_ROOT / segment
+    logging.info(f"Copying data from {source} to {destination}")
+    os.makedirs(destination, exist_ok=True)
+    for tape in TAPES:
+        files = source.glob(f"{tape}.tile*")
+        for file in files:
+            shutil.copy(file, destination)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    
+    restored_segments = []
+    for segment in SEGMENTS:
+        if segment < FIRST_UNRESTORED_SEGMENT and segment not in RERUN_SEGMENTS:
+            restored_segments.append(segment)
+
+    for segment in restored_segments:
+        copy(segment)

--- a/misc/create_dummy_uncombined_plus_4K_data.py
+++ b/misc/create_dummy_uncombined_plus_4K_data.py
@@ -1,0 +1,46 @@
+# #!/usr/bin/env python
+import logging
+import os
+
+from pathlib import Path
+
+ROOT = Path("/scratch/cimes/GLOBALFV3/stellar_run")
+SIMULATION = "20191020.00Z.C3072.L79x2_pire_PLUS_4K"
+TARGET_ROOT = Path("/scratch/gpfs/skclark/2023-09-15-X-SHiELD-symlinks")
+RERUN_SEGMENTS = ["2019102000"]  # Needed to be re-run (so uncombined)
+FIRST_UNRESTORED_SEGMENT = "2020022700"
+TAPES = [
+    "pire_atmos_dyn_3h_coarse_inst",
+    "pire_atmos_dyn_plev_coarse_3h",
+    "pire_atmos_phys_3h_coarse",
+    "pire_atmos_static_coarse"
+]
+TILES = range(1, 7)
+SUBTILES = [f"{subtile:04d}" for subtile in range(4)]
+
+
+def create_dummy_files(segment, tape):
+    root = TARGET_ROOT / SIMULATION / "history" / segment
+    if not os.path.exists(root):
+        os.makedirs(root)
+
+    for tile in TILES:
+        for subtile in SUBTILES:
+            filename = root / f"{tape}.tile{tile}.nc.{subtile}"
+            logging.info(f"Creating dummy file at {filename}")
+            open(filename, "a").close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    history = ROOT / "transferred" / SIMULATION / "history"
+    segments = sorted(os.listdir(history))
+
+    restored_segments = []
+    for segment in segments:
+        if segment < FIRST_UNRESTORED_SEGMENT and segment not in RERUN_SEGMENTS:
+            restored_segments.append(segment)
+
+    for segment in restored_segments:
+        for tape in TAPES:
+            create_dummy_files(segment, tape)

--- a/submit.sh
+++ b/submit.sh
@@ -3,9 +3,21 @@ set -e
 
 # conda environment: 2023-09-18-X-SHiELD-snakemake
 
+# The multi-year X-SHiELD simulations were run in two stages, and so the raw
+# data exists in two places.  Before running the snakemake workflow it is
+# therefore important to merge these datasets together through symbolic links.
+python misc/symlink_data.py
+
+# We must run some additional scripts to work around diagnostic data that needed
+# to be restored from ppan:/archive for the plus-4K simulation.  This data was
+# already run through mppnccombine, and therefore the mppnccombine steps for
+# just these segments can be skipped.  These scripts provide a crude way for
+# snakemake to recognize this.
+python misc/create_dummy_uncombined_plus_4K_data.py
+python misc/copy_plus_4K_diagnostics.py
+
 # Run this workflow in stages, since the graph will be large.  Also group
-# mppnccombine jobs within batch jobs since there will be a huge number
-# of them.
+# mppnccombine jobs within batch jobs since there will be a huge number of them.
 n_batches=64
 
 for batch in $(seq 1 ${n_batches})


### PR DESCRIPTION
There was missing diagnostics data for a stretch of segments in the +4 K case.  Fortunately this data was backed up on `/archive`, though it was archived in its already combined state.  Since the workflow expects data from all segments to be initially uncombined, this required a bit of scripting to work around.